### PR TITLE
Fix for generating a drop schema statement with a cascade clause (always)

### DIFF
--- a/src/lobos/migration.clj
+++ b/src/lobos/migration.clj
@@ -52,7 +52,9 @@
    form))
 
 (defn complement [action]
-  (cond 
+  (cond
+    (and (= (first action) 'create) (= (first (nth action 2 nil)) 'schema))
+    (lazy-seq (assoc (vec (apply list 'drop (rest action))) 3 :cascade))
     (= (first action) 'create)
     (apply list 'drop (rest action))
     (= (first action) 'alter)

--- a/test/lobos/test/integration.clj
+++ b/test/lobos/test/integration.clj
@@ -46,6 +46,18 @@
       (is (not= (inspect-schema :sname) :lobos)
           "A schema named 'lobos' should have been dropped"))))
 
+(def-db-test test-create-and-drop-schema-with-tables
+  (when (with-db-meta (get-db-spec *db*)
+          (or (supports-schemas)
+              (supports-catalogs)))
+    (with-schema [lobos :lobos]
+      (is (= (inspect-schema) lobos)
+          "A schema named 'lobos' should have been created")
+      (create lobos (table :foo (integer :bar)))
+      (drop *db* lobos :cascade)
+      (is (not= (inspect-schema :sname) :lobos)
+          "A schema named 'lobos' should have been dropped"))))
+
 (def-db-test test-create-and-drop-table
   (with-schema [lobos :lobos]
     (create lobos (table :foo (integer :bar)))

--- a/test/lobos/test/migration.clj
+++ b/test/lobos/test/migration.clj
@@ -1,0 +1,13 @@
+(ns lobos.test.migration
+  (:refer-clojure :exclude [alter compile defonce drop
+                            bigint boolean char double float time complement])
+  (:use clojure.test
+        lobos.migration))
+
+(deftest test-complement-for-drop-table-statement
+  (is (= '(drop db (table :users (integer :id))) (complement '(create db (table :users (integer :id)))))
+      "should generate correct drop table statement"))
+
+(deftest test-complement-for-drop-schema-statement
+  (is (= '(drop db (schema :users) :cascade) (complement '(create db (schema :users))))
+      "should generate correct drop schema statement with a cascade clause"))


### PR DESCRIPTION
Hi Nicolas,

I generated a couple of tables inside a schema, and after I ran dump, the migrations file did not have a :cascade clause for the drop schema statement.

I've tried to include the fix for the above issue and also added a couple tests. Please merge if this fix is OK.

Regards,
Manoj.
