### PR TITLE
Clojure 1.3.0 compatibility (Clojure-Contrib dep removed)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 .cake
+.lein-failures
 
 .lobos_stash.clj
 src/lobos/migrations.clj

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,8 @@
   :description
   "A library to create and manipulate SQL database schemas."
   :dependencies [[org.clojure/clojure "1.2.1"]
-                 [org.clojure/clojure-contrib "1.2.0"]]
+                 [org.clojure/java.jdbc "0.0.6"]
+                 [org.clojure/tools.macro "0.1.0"]]
   :dev-dependencies [[swank-clojure "1.3.2"]
                      [lein-clojars "0.7.0"]
                      [marginalia "0.6.0"]

--- a/src/lobos/analyzer.clj
+++ b/src/lobos/analyzer.clj
@@ -11,8 +11,7 @@
   (:refer-clojure :exclude [defonce replace])
   (:require (lobos [connectivity :as conn]
                    [schema :as schema]))
-  (:use (clojure.contrib [def :only [defvar-]])
-        (clojure [string :only [replace]])
+  (:use (clojure [string :only [replace]])
         lobos.internal
         lobos.metadata
         lobos.utils)

--- a/src/lobos/backends/h2.clj
+++ b/src/lobos/backends/h2.clj
@@ -11,7 +11,6 @@
   (:refer-clojure :exclude [compile defonce])
   (:require (lobos [schema :as schema]))
   (:use (clojure [string :only [split]])
-        (clojure.contrib [def :only [defvar-]])
         (lobos analyzer compiler connectivity internal metadata utils))
   (:import (lobos.ast AlterRenameAction
                       AutoIncClause

--- a/src/lobos/backends/mysql.clj
+++ b/src/lobos/backends/mysql.clj
@@ -11,8 +11,7 @@
   (:refer-clojure :exclude [compile defonce])
   (:require (lobos [schema :as schema]
                    [ast :as ast]))
-  (:use (clojure.contrib [def :only [defvar-]])
-        (lobos [schema :only [build-definition]]
+  (:use (lobos [schema :only [build-definition]]
                analyzer
                compiler
                metadata
@@ -28,7 +27,7 @@
 
 ;; ## Analyzer
 
-(defvar- analyzer-data-type-aliases
+(def ^{:private true} analyzer-data-type-aliases
   {:bit :boolean
    :int :integer
    :text :clob
@@ -89,7 +88,7 @@
                    (filter identity)
                    (map #(when % (as-str \` % \`)))))))
 
-(defvar- compiler-data-type-aliases
+(def ^{:private true} compiler-data-type-aliases
   {:clob :text
    :nclob :text})
 

--- a/src/lobos/backends/postgresql.clj
+++ b/src/lobos/backends/postgresql.clj
@@ -10,8 +10,7 @@
   "Compiler implementation for PostgreSQL."
   (:refer-clojure :exclude [compile defonce])
   (:require (lobos [schema :as schema]))
-  (:use (clojure.contrib [def :only [defvar-]])
-        lobos.analyzer
+  (:use lobos.analyzer
         lobos.compiler
         lobos.utils)
   (:import (lobos.ast AlterRenameAction
@@ -24,7 +23,7 @@
 
 ;; ## Analyzer
 
-(defvar- analyzer-data-type-aliases
+(def ^{:private true} analyzer-data-type-aliases
   {:bool :boolean
    :bpchar :char
    :bytea :blob
@@ -56,7 +55,7 @@
 
 ;; ## Compiler
 
-(defvar- compiler-data-type-aliases
+(def ^{:private true} compiler-data-type-aliases
   {:blob :bytea
    :clob :text
    :double :double-precision

--- a/src/lobos/backends/sqlite.clj
+++ b/src/lobos/backends/sqlite.clj
@@ -10,8 +10,7 @@
   "Compiler implementation for SQLite."
   (:refer-clojure :exclude [compile defonce])
   (:require (lobos [schema :as schema]))
-  (:use (clojure.contrib [def :only [defvar-]])
-        (lobos analyzer compiler connectivity internal metadata utils))
+  (:use (lobos analyzer compiler connectivity internal metadata utils))
   (:import (lobos.ast AlterTableStatement
                       AutoIncClause
                       CreateSchemaStatement
@@ -28,7 +27,7 @@
 
 ;; ## Analyzer
 
-(defvar- analyzer-data-type-aliases
+(def ^{:private true} analyzer-data-type-aliases
   {:time-with-time-zone :time
    :timestamp-with-time-zone :timestamp})
 

--- a/src/lobos/backends/sqlserver.clj
+++ b/src/lobos/backends/sqlserver.clj
@@ -11,8 +11,7 @@
   (:refer-clojure :exclude [compile defonce])
   (:require clojure.string
             (lobos [schema :as schema]))
-  (:use (clojure.contrib [def :only [defvar-]])
-        lobos.analyzer
+  (:use lobos.analyzer
         lobos.compiler
         lobos.metadata
         lobos.utils)
@@ -42,7 +41,7 @@
            (let [[[_ n]] (re-seq #"(\w+)(\(\))?" expr)]
              (Integer/parseInt n))))))
 
-(defvar- analyzer-data-type-aliases
+(def ^{:private true} analyzer-data-type-aliases
   {:bit :boolean
    :datetime2 :timestamp
    :image :blob
@@ -87,7 +86,7 @@
     (str (as-sql-keyword name)
          (as-list (map compile args)))))
 
-(defvar- compiler-data-type-aliases
+(def ^{:private true} compiler-data-type-aliases
   {:blob      :image
    :boolean   :bit
    :clob      :text

--- a/src/lobos/connectivity.clj
+++ b/src/lobos/connectivity.clj
@@ -9,9 +9,8 @@
 (ns lobos.connectivity
   "A set of connectivity functions."
   (:refer-clojure :exclude [defonce])
-  (:require (clojure.contrib.sql [internal :as sqlint]))
-  (:use (clojure.contrib [def :only [defalias defvar]])
-        lobos.utils))
+  (:require (clojure.java.jdbc [internal :as sqlint]))
+  (:use lobos.utils))
 
 ;; -----------------------------------------------------------------------------
 
@@ -25,9 +24,9 @@
 
 ;; ## Helpers
 
-(defalias find-connection sqlint/find-connection*)
+(def find-connection sqlint/find-connection*)
 
-(defalias connection sqlint/connection*)
+(def connection sqlint/connection*)
 
 (defn get-db-spec
   "Returns the associated db-spec or itself. *For internal use*."

--- a/src/lobos/core.clj
+++ b/src/lobos/core.clj
@@ -23,7 +23,7 @@
                    [connectivity :as conn]
                    [migration :as mig]
                    [schema :as schema]))
-  (:use (clojure.contrib [def :only [name-with-attributes]])
+  (:use (clojure.tools [macro :only [name-with-attributes]])
         (clojure [pprint :only [pprint]])
         lobos.internal
         lobos.utils))

--- a/src/lobos/internal.clj
+++ b/src/lobos/internal.clj
@@ -12,7 +12,7 @@
                    [connectivity :as conn]
                    [metadata :as metadata]
                    [schema :as schema]))
-  (:use (clojure.contrib [def :only [name-with-attributes]])
+  (:use (clojure.tools [macro :only [name-with-attributes]])
         lobos.utils))
 
 (defonce debug-level

--- a/src/lobos/metadata.clj
+++ b/src/lobos/metadata.clj
@@ -8,19 +8,18 @@
 
 (ns lobos.metadata
   "Helpers to query the database's meta-data."
-  (:require (clojure.contrib.sql [internal :as sqlint])
+  (:require (clojure.java.jdbc [internal :as sqlint])
             (lobos [compiler :as compiler]
                    [connectivity :as conn]
                    [schema :as schema]))
-  (:use (clojure.contrib [def :only [defvar-]]))
   (:import (java.sql DatabaseMetaData)))
 
 ;; -----------------------------------------------------------------------------
 
 ;; ## Database Metadata
 
-(defvar- *db-meta* nil)
-(defvar- *db-meta-spec* nil)
+(def ^{:private true} *db-meta* nil)
+(def ^{:private true} *db-meta-spec* nil)
 
 (defn db-meta
   "Returns the binded DatabaseMetaData object found in *db-meta* or get

--- a/src/lobos/migration.clj
+++ b/src/lobos/migration.clj
@@ -9,14 +9,14 @@
 (ns lobos.migration
   "Migrations support."
   (:refer-clojure :exclude [complement defonce replace])
-  (:require (clojure.contrib [sql :as sql])
+  (:require (clojure.java [jdbc :as sql])
             (lobos [analyzer :as analyzer]
                    [compiler :as compiler]
                    [connectivity :as conn]
                    [schema :as schema]))
   (:use (clojure [walk :only [postwalk]])
         (clojure.java [io :only [file writer]])
-        (clojure.contrib [def :only [defvar name-with-attributes]])
+        (clojure.tools [macro :only [name-with-attributes]])
         (clojure pprint)
         lobos.internal
         lobos.utils)
@@ -87,10 +87,10 @@
 
 ;; ## Migration Protocol
 
-(defvar migrations
-  (atom [])
-  "Used to agregate migrations in order of definition, *For internal
-  use*.")
+(def ^{:doc "Used to agregate migrations in order of definition,
+  *For internal use*."}
+  migrations
+  (atom []))
 
 (defprotocol Migration
   "The migration protocol is meant to be reified into a single migration

--- a/src/lobos/schema.clj
+++ b/src/lobos/schema.clj
@@ -29,7 +29,6 @@
   (:use (clojure [walk   :only [postwalk]]
                  [set    :only [union]]
                  [string :only [replace]])
-        (clojure.contrib [def :only [defalias defvar]])
         lobos.utils))
 
 (ast/import-all)
@@ -85,27 +84,27 @@
 
 ;; ## Expression Definitions
 
-(defvar sql-infix-operators
+(def ^{:doc "A set of symbol representing SQL infix operators."}
+  sql-infix-operators
   '#{;; math operators
      + - * /
      ;; boolean operators
-     < > <= >= = != or and in like}
-  "A set of symbol representing SQL infix operators.")
+     < > <= >= = != or and in like})
 
-(defvar sql-prefix-operators
-  '#{not}
-  "A set of symbol representing SQL prefix operators.")
+(def ^{:doc "A set of symbol representing SQL prefix operators."}
+  sql-prefix-operators
+  '#{not})
 
-(defvar sql-functions
+(def ^{:doc "A set of symbol representing SQL functions."}
+  sql-functions
   '#{;; string functions
      length lower position replace str subs trim upper
      ;; numeric functions
      abs ceil floor mod
      ;; datetime functions
-     extract now current_date current_time current_timestamp}
-  "A set of symbol representing SQL functions.")
+     extract now current_date current_time current_timestamp})
 
-(defvar sql-symbols
+(def sql-symbols
   (union sql-infix-operators
          sql-prefix-operators
          sql-functions))
@@ -556,7 +555,7 @@
   real
   double-precision)
 
-(defalias double double-precision)
+(def double double-precision)
 
 (def-optional-precision-typed-columns
   float)
@@ -569,9 +568,9 @@
   clob
   nclob)
 
-(defalias text clob)
+(def text clob)
 
-(defalias ntext nclob)
+(def ntext nclob)
 
 (def-length-bounded-typed-columns  
   varchar

--- a/test/lobos/test.clj
+++ b/test/lobos/test.clj
@@ -9,7 +9,7 @@
 (ns lobos.test
   (:refer-clojure :exclude [alter defonce drop])
   (:use clojure.test
-        (clojure.contrib [io :only [delete-file file]])
+        (clojure.java [io :only [delete-file file]])
         (lobos analyzer connectivity core utils)
         (lobos [schema :only [schema]]))
   (:import (java.lang UnsupportedOperationException)))

--- a/test/lobos/test/connectivity.clj
+++ b/test/lobos/test/connectivity.clj
@@ -14,7 +14,7 @@
 
 (defn cnx-fixture [f]
   (binding [*cnx* (reify java.sql.Connection (close [this] nil))
-            clojure.contrib.sql.internal/get-connection (fn [& _] *cnx*)]
+            clojure.java.jdbc.internal/get-connection (fn [& _] *cnx*)]
     (f)))
 
 (use-fixtures :each cnx-fixture)

--- a/test/lobos/test/system.clj
+++ b/test/lobos/test/system.clj
@@ -8,7 +8,7 @@
 
 (ns lobos.test.system
   (:refer-clojure :exclude [compile conj! disj! distinct drop sort take])
-  (:require (clojure.contrib [sql :as sql])
+  (:require (clojure.java [jdbc :as sql])
             (lobos [compiler :as compiler]
                    [connectivity :as conn]))
   (:use clojure.test
@@ -63,8 +63,8 @@
                    (sql/insert-records (table :users)
                                        {(identifier :name) "x"}))
           "An exception should have been thrown because of a check constraint")
-      (is (nil? (sql/insert-records (table :users)
-                                    {(identifier :name) "foo"}))
+      (is (sql/insert-records (table :users)
+                              {(identifier :name) "foo"})
           "The insert statement should not throw an exception"))))
 
 (def-db-test test-unique-constraint
@@ -74,8 +74,8 @@
                  (sql/insert-records (table :users)
                                      {(identifier :name) "foo"}))
         "An exception should have been thrown because of an unique constraint")
-    (is (nil? (sql/insert-records (table :users)
-                                  {(identifier :name) "bar"}))
+    (is (sql/insert-records (table :users)
+                            {(identifier :name) "bar"})
         "The insert statement should not throw an exception")))
 
 ;;; Using hardcoded id is a bad idea!
@@ -88,7 +88,7 @@
                                        {(identifier :title) "foo"
                                         (identifier :user_id) 2}))
           "An exception should have been thrown because of a foreign key constraint")
-      (is (nil? (sql/insert-records (table :posts)
-                                    {(identifier :title) "foo"
-                                     (identifier :user_id) 1}))
+      (is (sql/insert-records (table :posts)
+                              {(identifier :title) "foo"
+                               (identifier :user_id) 1})
           "The insert statement should not throw an exception"))))


### PR DESCRIPTION
This pull request removes Clojure-Contrib as a dependency from Lobos, allowing it to be used in Clojure 1.3.0 projects.
