### PR TITLE
Support both 1.x and 2.x versions of java.jdbc [#43]

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject lobos "1.0.0-SNAPSHOT"
+(defproject org.clojars.jcrossley3/lobos "1.0.0-SNAPSHOT"
   :description
-  "A library to create and manipulate SQL database schemas."
+  "Compatible with both 0.1.x and 0.2.x versions of java.jdbc"
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [org.clojure/java.jdbc "0.1.1"]
                  [org.clojure/tools.macro "0.1.1"]]

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description
   "A library to create and manipulate SQL database schemas."
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [org.clojure/java.jdbc "0.2.3"]
+                 [org.clojure/java.jdbc "0.1.1"]
                  [org.clojure/tools.macro "0.1.1"]]
   :dev-dependencies [[lein-clojars "0.7.0"]
                      [lein-marginalia "0.6.1"]

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description
   "A library to create and manipulate SQL database schemas."
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [org.clojure/java.jdbc "0.1.1"]
+                 [org.clojure/java.jdbc "0.2.3"]
                  [org.clojure/tools.macro "0.1.1"]]
   :dev-dependencies [[lein-clojars "0.7.0"]
                      [lein-marginalia "0.6.1"]

--- a/src/lobos/connectivity.clj
+++ b/src/lobos/connectivity.clj
@@ -9,8 +9,12 @@
 (ns lobos.connectivity
   "A set of connectivity functions."
   (:refer-clojure :exclude [defonce])
-  (:require (clojure.java.jdbc [internal :as sqlint]))
   (:use lobos.utils))
+
+(try
+  (require 'lobos.connectivity.jdbc-1)
+  (catch Throwable e
+    (require 'lobos.connectivity.jdbc-2)))
 
 ;; -----------------------------------------------------------------------------
 
@@ -28,11 +32,13 @@
 
 (def connection sqlint/connection*)
 
+(defn jdbc-db-spec [] (:db-spec sqlint/*db*))
+
 (defn get-db-spec
   "Returns the associated db-spec or itself. *For internal use*."
   [& [connection-info]]
   (let [connection-info (or connection-info :default-connection)]
-    (or (:db-spec sqlint/*db*)
+    (or (jdbc-db-spec)
         (if (keyword? connection-info)
           (-> @global-connections connection-info :db-spec)
           connection-info))))

--- a/src/lobos/connectivity/jdbc_1.clj
+++ b/src/lobos/connectivity/jdbc_1.clj
@@ -1,0 +1,11 @@
+; Copyright (c) Nicolas Buduroi. All rights reserved.
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 which can be found in the file
+; epl-v10.html at the root of this distribution. By using this software
+; in any fashion, you are agreeing to be bound by the terms of this
+; license.
+; You must not remove this notice, or any other, from this software.
+
+(ns lobos.connectivity
+  (:refer-clojure :exclude [defonce])
+  (:require [clojure.java.jdbc.internal :as sqlint]))

--- a/src/lobos/connectivity/jdbc_2.clj
+++ b/src/lobos/connectivity/jdbc_2.clj
@@ -1,0 +1,17 @@
+; Copyright (c) Nicolas Buduroi. All rights reserved.
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 which can be found in the file
+; epl-v10.html at the root of this distribution. By using this software
+; in any fashion, you are agreeing to be bound by the terms of this
+; license.
+; You must not remove this notice, or any other, from this software.
+
+(ns lobos.connectivity
+  (:refer-clojure :exclude [defonce])
+  (:require [clojure.java.jdbc :as sqlint]))
+
+(in-ns 'clojure.java.jdbc)
+(let [old *db*] (def ^{:private false :dynamic true} *db* old))
+(let [old get-connection] (def get-connection (fn [& args] (apply old args))))
+(def find-connection* find-connection)
+(def connection* connection)

--- a/src/lobos/metadata.clj
+++ b/src/lobos/metadata.clj
@@ -8,8 +8,7 @@
 
 (ns lobos.metadata
   "Helpers to query the database's meta-data."
-  (:require (clojure.java.jdbc [internal :as sqlint])
-            (lobos [compiler :as compiler]
+  (:require (lobos [compiler :as compiler]
                    [connectivity :as conn]
                    [schema :as schema]))
   (:import (java.sql DatabaseMetaData)))
@@ -33,7 +32,7 @@
 
 (defn db-meta-spec
   []
-  (or (:db-spec sqlint/*db*)
+  (or (conn/jdbc-db-spec)
       *db-meta-spec*
       (conn/get-db-spec :default-connection)))
 


### PR DESCRIPTION
We introduce a bit of isolated monkey patchery to allow the existing code to work when clojure.java.jdbc 0.2.x, which collapsed the internal namespace, is found in the classpath.
