### PR TITLE
Maintain column order from migration, even with 10+ columns

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,8 @@
   :license {:name "Eclipse Public License"}
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [org.clojure/java.jdbc "0.1.1"]
-                 [org.clojure/tools.macro "0.1.1"]]
+                 [org.clojure/tools.macro "0.1.1"]
+                 [org.flatland/ordered "1.4.0"]]
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              ;:1.5 {:dependencies [[org.clojure/clojure "1.5.0-beta1"]]}
              :dev

--- a/src/lobos/schema.clj
+++ b/src/lobos/schema.clj
@@ -29,7 +29,8 @@
   (:use (clojure [walk   :only [postwalk]]
                  [set    :only [union]]
                  [string :only [replace]])
-        lobos.utils))
+        lobos.utils
+        flatland.ordered.map))
 
 (ast/import-all)
 
@@ -689,7 +690,7 @@
   [name & [columns constraints indexes]]
   (name-required name "table")
   (Table. name
-          (or columns {})
+          (or columns (ordered-map))
           (or constraints {})
           (or indexes {})))
 
@@ -697,7 +698,7 @@
   "Constructs an abstract table definition containing the given
   elements."
   [name & elements]
-  `(-> (table* ~name) ~@(reverse elements)))
+  `(-> (table* ~name) ~@elements))
 
 ;; -----------------------------------------------------------------------------
 

--- a/test/lobos/test/schema.clj
+++ b/test/lobos/test/schema.clj
@@ -218,7 +218,20 @@
       "Table with column")
   (is (= (table :foo (unique :bar [:a]))
          (Table. :foo {} {:bar (UniqueConstraint. :bar :unique [:a])} {}))
-      "Table with constraint"))
+      "Table with constraint")
+  (is (= (list :col1 :col2 :col3 :col4 :col5 :col6 :col7 :col8 :col9 :col10)
+         (keys (:columns (table :foo
+                                (column :col1 nil nil)
+                                (column :col2 nil nil)
+                                (column :col3 nil nil)
+                                (column :col4 nil nil)
+                                (column :col5 nil nil)
+                                (column :col6 nil nil)
+                                (column :col7 nil nil)
+                                (column :col8 nil nil)
+                                (column :col9 nil nil)
+                                (column :col10 nil nil)))))
+      "Table with many ordered columns"))
 
 ;;;; Schema definition tests
 


### PR DESCRIPTION
Currently, up to 9 columns, the correct order is maintained in the table definition (first listing below). However, upon hitting 10 columns, the order is lost (second listing). I've forced the column map to now be ordered, and now any number of columns can be added without losing the order (third listing). I've done this by taking a dependency on [ordered](https://github.com/flatland/ordered), I hope that's acceptable.

The driver for this was ClojureQL's implementation of JDBC's `.getGeneratedKeys`, which expects a primary key column to be the first that it finds when inserting.

```
user> (pprint (table :test
                     (integer :col1)
                     (integer :col2)
                     (integer :col3)
                     (integer :col4)
                     (integer :col5)
                     (integer :col6)
                     (integer :col7)
                     (integer :col7)
                     (integer :col8)
                     (integer :col9)))
{:name :test,
 :columns
 {:col1
  {:cname :col1,
   :data-type {:name :integer, :args [], :options {}},
   :default nil,
   :auto-inc nil,
   :not-null nil,
   :others ()},
  .
  .
  .
  {:cname :col9,
   :data-type {:name :integer, :args [], :options {}},
   :default nil,
   :auto-inc nil,
   :not-null nil,
   :others ()}},
 :constraints {},
 :indexes {}}
```

```
user> (pprint (table :test
                     (integer :col1)
                     (integer :col2)
                     (integer :col3)
                     (integer :col4)
                     (integer :col5)
                     (integer :col6)
                     (integer :col7)
                     (integer :col7)
                     (integer :col8)
                     (integer :col9)
                     (integer :col10)))
{:name :test,
 :columns
 {:col6
  {:cname :col6,
   :data-type {:name :integer, :args [], :options {}},
   :default nil,
   :auto-inc nil,
   :not-null nil,
   :others ()},
  :col7
  {:cname :col7,
   :data-type {:name :integer, :args [], :options {}},
   :default nil,
   :auto-inc nil,
   :not-null nil,
   :others ()},
  :col4
  {:cname :col4,
   :data-type {:name :integer, :args [], :options {}},
   :default nil,
   :auto-inc nil,
   :not-null nil,
   :others ()},
  :col5
  .
  .
  .
```

```
user> (pprint (table :test
                     (integer :col1)
                     (integer :col2)
                     (integer :col3)
                     (integer :col4)
                     (integer :col5)
                     (integer :col6)
                     (integer :col7)
                     (integer :col7)
                     (integer :col8)
                     (integer :col9)
                     (integer :col10)))
{:name :test,
 :columns
 {:col1
  {:cname :col1,
   :data-type {:name :integer, :args [], :options {}},
   :default nil,
   :auto-inc nil,
   :not-null nil,
   :others ()},
  :col2
  .
  .
  .
  {:cname :col10,
   :data-type {:name :integer, :args [], :options {}},
   :default nil,
   :auto-inc nil,
   :not-null nil,
   :others ()}},
 :constraints {},
 :indexes {}}
```
