### PR TITLE
upgrading java.jdbc version and removed checking the existence of files

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.emil0r/lobos "1.0.0-beta1"
+(defproject org.clojars.emil0r/lobos "1.0.0-beta2"
   :description
   "A library to create and manipulate SQL database schemas."
   :url "http://budu.github.com/lobos/"

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject lobos "1.0.0-beta1"
+(defproject org.clojars.emil0r/lobos "1.0.0-beta1"
   :description
   "A library to create and manipulate SQL database schemas."
   :url "http://budu.github.com/lobos/"
   :license {:name "Eclipse Public License"}
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.clojure/java.jdbc "0.1.1"]
+                 [org.clojure/java.jdbc "0.3.0-alpha5"]
                  [org.clojure/tools.macro "0.1.1"]]
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              ;:1.5 {:dependencies [[org.clojure/clojure "1.5.0-beta1"]]}

--- a/src/lobos/migration.clj
+++ b/src/lobos/migration.clj
@@ -182,7 +182,7 @@
 
 (defn list-migrations []
   (if *reload-migrations*
-    (when (.exists (migrations-file))
+    (do
       (swap! migrations (constantly []))
       (use :reload *migrations-namespace*)
       @migrations)


### PR DESCRIPTION
Upgraded version of java.jdbc to something a bit more recent as I couldn't use the library on more up to date java versions.

Also removed the check for the existence of files since it hindered migration defined in other jar files. If you really want this to still exist I could add some logic to work around it if you'd like.

Could you please accept even though you're inactive?
