### PR TITLE
Make lobos.migration/ns-file support options in libspecs

### DIFF
--- a/src/lobos/migration.clj
+++ b/src/lobos/migration.clj
@@ -136,10 +136,11 @@
     (pprint content wtr)))
 
 (defn ns-file [ns]
-  (file *src-directory*
-        (-> (str ns)
-            (.replace "." "/")
-            (str ".clj"))))
+  (let [n-name (if (coll? ns) (first ns) ns)]
+    (file *src-directory*
+          (-> (str n-name)
+              (.replace "." "/")
+              (str ".clj")))))
 
 ;; ### Stash File Helpers
 

--- a/test/lobos/test/migration.clj
+++ b/test/lobos/test/migration.clj
@@ -88,6 +88,12 @@
            (-> "src/foo/bar.clj"
                (.replace \/ java.io.File/separatorChar)))
         (str "Should return a File object with a path to the migrations "
+             "namespace")))
+  (binding [*migrations-namespace* '[foo.bar :exclude [baz]]]
+    (is (= (.getPath (migrations-file))
+           (-> "src/foo/bar.clj"
+               (.replace \/ java.io.File/separatorChar)))
+        (str "Should return a File object with a path to the migrations "
              "namespace"))))
 
 (deftest test-create-mfile
@@ -223,7 +229,7 @@
     (do-migrations *db* :lobos :down '[foo baz] true)
     (is (= (pending-migrations *db* :lobos) (list "foo" "bar" "baz"))
         "Should return a list containing 'foo' 'bar' and 'baz'")))
-    
+
 (deftest test-generate-migration*
   (with-migrations-table
     (delete-file (migrations-file) true)


### PR DESCRIPTION
Make ns-file able to support use options when resolving namespace file path.

Example:

If `foo.bar` and `foo.baz` both have a var named `qux`:

```
(doseq [mns ['[foo.bar :exclude [qux]] '[foo.baz :exclude [qux]]]
  (binding [*migrations-namespace* mns]
    (do-something)))
```

or simply:

```
(binding [*migrations-namespace* '[foo.bar :exclude [qux]]]
  (do-something))
```
