### PR TITLE
Migration jdbc version 3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :url "http://budu.github.com/lobos/"
   :license {:name "Eclipse Public License"}
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.clojure/java.jdbc "0.3.0-beta1"]
+                 [org.clojure/java.jdbc "0.3.3"]
                  [org.clojure/tools.macro "0.1.2"]]
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
-(defproject lobos "1.0.0-beta1"
+(defproject sicia/lobos "1.0.0-beta2"
   :description
   "A library to create and manipulate SQL database schemas."
-  :url "http://budu.github.com/lobos/"
+  :url "http://github.com/siscia/lobos"
   :license {:name "Eclipse Public License"}
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [org.clojure/java.jdbc "0.3.3"]

--- a/src/lobos/connectivity.clj
+++ b/src/lobos/connectivity.clj
@@ -14,7 +14,12 @@
 (try
   (require 'lobos.connectivity.jdbc-1)
   (catch Throwable e
-    (require 'lobos.connectivity.jdbc-2)))
+    (try
+      (require 'lobos.connectivity.jdbc-2)
+      (catch Throwable e
+        (do
+          (ns-unalias 'lobos.connectivity 'sqlint)
+          (require 'lobos.connectivity.jdbc-3))))))
 
 ;; -----------------------------------------------------------------------------
 

--- a/src/lobos/connectivity/jdbc_3.clj
+++ b/src/lobos/connectivity/jdbc_3.clj
@@ -1,0 +1,17 @@
+; Copyright (c) Simone Mosciatti. All rights reserved.
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 which can be found in the file
+; epl-v10.html at the root of this distribution. By using this software
+; in any fashion, you are agreeing to be bound by the terms of this
+; license.
+; You must not remove this notice, or any other, from this software.
+
+(ns lobos.connectivity
+  (:refer-clojure :exclude [defonce])
+  (:require [clojure.java.jdbc.deprecated :as sqlint]))
+
+(in-ns 'clojure.java.jdbc.deprecated)
+(let [old *db*] (def ^{:private false :dynamic true} *db* old))
+(let [old get-connection] (def get-connection (fn [& args] (apply old args))))
+(def find-connection* find-connection)
+(def connection* connection)

--- a/src/lobos/migration.clj
+++ b/src/lobos/migration.clj
@@ -9,7 +9,7 @@
 (ns lobos.migration
   "Migrations support."
   (:refer-clojure :exclude [complement defonce replace])
-  (:require (clojure.java [jdbc :as sql])
+  (:require (clojure.java.jdbc [deprecated :as sql])
             (lobos [analyzer :as analyzer]
                    [compiler :as compiler]
                    [connectivity :as conn]

--- a/test/lobos/test/system.clj
+++ b/test/lobos/test/system.clj
@@ -8,7 +8,7 @@
 
 (ns lobos.test.system
   (:refer-clojure :exclude [compile conj! disj! distinct drop sort take])
-  (:require (clojure.java [jdbc :as sql])
+  (:require (clojure.java.jdbc [deprecated :as sql])
             (lobos [compiler :as compiler]
                    [connectivity :as conn]))
   (:use clojure.test


### PR DESCRIPTION
Hi,

I wrote this little update, it is now possible to use lobos with jdbc versione 3.

All the test pass, hopefully it should be enough.

Greets.

PS: Still, IMHO should be better to drop the support for the old jdbc driver and update everything, it is not too much work.
