### PR TITLE
Add support for use of opened connection

### DIFF
--- a/test/lobos/test/connectivity.clj
+++ b/test/lobos/test/connectivity.clj
@@ -65,6 +65,11 @@
          *cnx*)
       "With connection specification"))
 
+(deftest test-with-opened-connection
+  (is (= (with-opened-connection {:connection *cnx*} #(connection))
+         *cnx*)
+      "With opened connection provided"))
+
 (deftest test-with-connection
   (is (= (with-connection {}
            (connection))


### PR DESCRIPTION
Instead of opening new connections quite often or rely on a global one,
use a connection provided from outside.

An added benefit of this change is the ability to do a set of actions inside 
a single transaction.
